### PR TITLE
chore: add repo structure and CI pipeline

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 200
+extend-ignore = W292

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.txt
+      - name: Lint
+        run: flake8 .
+      - name: Test
+        run: pytest
+      - name: Build Docker image
+        run: docker build -t eco-mercado-backend .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+CMD ["python", "server.py"]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
-# eco-mercado
+# Eco Mercado
+
+Proyecto monorepo con subdirectorios para backend, web y móvil.
+
+## Estructura
+- `backend/`: lógica del servidor.
+- `web/`: interfaz web.
+- `mobile/`: aplicación móvil.
+
+Incluye pipeline de pruebas unitarias, lint y construcción de imagen Docker mediante GitHub Actions.
+

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,4 @@
+# Backend
+
+Código y lógica del servidor de Eco Mercado.
+

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -1,0 +1,4 @@
+# Mobile
+
+Aplicación móvil de Eco Mercado.
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+flake8
+pytest

--- a/tests/test_sample.py
+++ b/tests/test_sample.py
@@ -1,0 +1,7 @@
+import json
+
+
+def test_products_file_exists():
+    with open('products.json', 'r', encoding='utf-8') as f:
+        data = json.load(f)
+    assert isinstance(data, list)

--- a/web/README.md
+++ b/web/README.md
@@ -1,0 +1,4 @@
+# Web
+
+Interfaz web de Eco Mercado.
+


### PR DESCRIPTION
## Summary
- set up backend, web, and mobile directories
- add unit test and lint workflow with Docker build
- configure flake8 and Dockerfile for backend

## Testing
- `flake8 .`
- `pytest`
- `docker build -t eco-mercado-backend .` *(fails: command not found: docker)*

------
https://chatgpt.com/codex/tasks/task_b_68a3e1152dd48325846090d34db9d051