### PR TITLE
Add JWT auth and GraphQL endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.pyc
+app.db
+pytest_cache/

--- a/models.py
+++ b/models.py
@@ -1,0 +1,19 @@
+from sqlalchemy import Column, Integer, String, Boolean
+from sqlalchemy.orm import declarative_base, sessionmaker
+from sqlalchemy import create_engine
+
+DATABASE_URL = 'sqlite:///./app.db'
+
+engine = create_engine(DATABASE_URL, connect_args={'check_same_thread': False})
+SessionLocal = sessionmaker(bind=engine)
+Base = declarative_base()
+
+
+class User(Base):
+    __tablename__ = 'users'
+
+    id = Column(Integer, primary_key=True, index=True)
+    email = Column(String, unique=True, index=True, nullable=False)
+    password_hash = Column(String, nullable=False)
+    is_verified = Column(Boolean, default=False)
+    verification_token = Column(String, unique=True, index=True, nullable=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,7 @@
 flake8
 pytest
+Flask
+Flask-Cors
+SQLAlchemy
+PyJWT
+graphene

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,36 @@
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from models import Base, engine, SessionLocal, User  # noqa: E402
+from app import app  # noqa: E402
+
+
+def setup_module(module):
+    Base.metadata.create_all(bind=engine)
+    db = SessionLocal()
+    db.query(User).delete()
+    db.commit()
+    db.close()
+
+
+def test_register_login_and_graphql():
+    client = app.test_client()
+    resp = client.post('/api/register', json={'email': 'test@example.com', 'password': 'secret'})
+    assert resp.status_code == 201
+    token = resp.get_json()['verification_token']
+
+    verify_resp = client.get(f'/api/verify/{token}')
+    assert verify_resp.status_code == 200
+
+    login_resp = client.post('/api/login', json={'email': 'test@example.com', 'password': 'secret'})
+    assert login_resp.status_code == 200
+    jwt_token = login_resp.get_json()['token']
+    assert jwt_token
+
+    query = {'query': '{ users { email isVerified } }'}
+    gql_resp = client.post('/graphql', json=query)
+    data = gql_resp.get_json()
+    assert data['data']['users'][0]['email'] == 'test@example.com'
+    assert data['data']['users'][0]['isVerified'] is True


### PR DESCRIPTION
## Summary
- create SQLAlchemy user model
- add registration, email verification, JWT login, and user GraphQL API
- cover auth flow with tests

## Testing
- `flake8`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68a3e228c2a08325a3c2f2a9c3e6b3ec